### PR TITLE
Fix curl example syntax and Content-Type header use

### DIFF
--- a/includes/_benchmarks.md
+++ b/includes/_benchmarks.md
@@ -16,7 +16,7 @@ GET https://api.surveymonkey.com/v3/benchmark_bundles
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/benchmark_bundles
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/benchmark_bundles
 ```
 
 ```python
@@ -105,7 +105,7 @@ GET https://api.surveymonkey.com/v3/benchmark_bundles/{bundle_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/benchmark_bundles/test_bundle
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/benchmark_bundles/test_bundle
 ```
 
 ```python
@@ -191,7 +191,7 @@ GET https://api.surveymonkey.com/v3/benchmark_bundles/{bundle_id}/analyze
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" 'https://api.surveymonkey.com/v3/benchmark_bundles/test_bundle/analyze?question_ids=25651,25652'
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" 'https://api.surveymonkey.com/v3/benchmark_bundles/test_bundle/analyze?question_ids=25651,25652'
 
 ```
 
@@ -302,7 +302,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/question
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions/{question_id}/benchmark
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions/{question_id}/benchmark
 ```
 
 ```python

--- a/includes/_collectors.md
+++ b/includes/_collectors.md
@@ -14,7 +14,7 @@ POST https://api.surveymonkey.com/v3/surveys/{survey_id}/collectors
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/collectors -d '{"type":"weblink"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys/1234/collectors -d '{"type":"weblink"}'
 ```
 
 ```python
@@ -125,7 +125,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/collectors/1234
 ```
 
 ```python
@@ -216,7 +216,7 @@ POST https://api.surveymonkey.com/v3/collectors/{collector_id}/messages
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages -d '{"type":"invite"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/collectors/1234/messages -d '{"type":"invite"}'
 ```
 
 ```python
@@ -301,7 +301,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/messages/{message_
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/collectors/1234/messages/1234
 ```
 
 ```python
@@ -368,7 +368,7 @@ POST https://api.surveymonkey.com/v3/collectors/{collector_id}/messages/{message
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/send -d '{"scheduled_date":"2015-10-06T12:56:55+00:00"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/send -d '{"scheduled_date":"2015-10-06T12:56:55+00:00"}'
 ```
 
 ```python
@@ -445,7 +445,7 @@ POST https://api.surveymonkey.com/v3/collectors/{collector_id}/messages/{message
 >Example Request (with contact_id)
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients -d '{"contact_id:"1234"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients -d '{"contact_id:"1234"}'
 ```
 
 ```python
@@ -467,7 +467,7 @@ s.post(url, json=payload)
 >Example Request (without contact_id)
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients-d '{"email":"test@surveymonkey.com"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients-d '{"email":"test@surveymonkey.com"}'
 ```
 
 ```python
@@ -591,7 +591,7 @@ If custom_fields are provided for any one contact, all contacts will have their 
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients/bulk -d '{"contact_ids":["1234", "5678"]}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/recipients/bulk -d '{"contact_ids":["1234", "5678"]}'
 ```
 
 ```python
@@ -686,7 +686,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/recipients
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/recipients
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/collectors/1234/recipients
 ```
 
 ```python
@@ -759,7 +759,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/recipients/{recipi
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/recipients/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/collectors/1234/recipients/1234
 ```
 
 ```python
@@ -836,7 +836,7 @@ GET https://api.surveymonkey.com/v3/collectors/{id}/messages/{id}/stats
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/stats
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/collectors/1234/messages/1234/stats
 ```
 
 ```python

--- a/includes/_contacts.md
+++ b/includes/_contacts.md
@@ -13,7 +13,7 @@ POST https://api.surveymonkey.com/v3/contact_lists
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists -d '{"name": "My Contact List"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_lists -d '{"name": "My Contact List"}'
 ```
 
 ```python
@@ -82,7 +82,7 @@ GET https://api.surveymonkey.com/v3/contact_lists/{contact_list_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/contact_lists/1234
 ```
 
 ```python
@@ -134,7 +134,7 @@ POST https://api.surveymonkey.com/v3/contact_lists/{contact_list_id}/copy
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists/1234/copy
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_lists/1234/copy
 ```
 
 ```python
@@ -182,7 +182,7 @@ POST https://api.surveymonkey.com/v3/contact_lists/{contact_list_id}/merge
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists/1234/merge -d '{ "list_id": "4321" }'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_lists/1234/merge -d '{ "list_id": "4321" }'
 ```
 
 ```python
@@ -240,7 +240,7 @@ POST https://api.surveymonkey.com/v3/contact_lists/{contact_list_id}/contacts
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists/1234/contacts -d '{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_lists/1234/contacts -d '{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com"}'
 ```
 
 ```python
@@ -337,7 +337,7 @@ POST https://api.surveymonkey.com/v3/contact_lists/{contact_list_id}/contacts/bu
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_lists/1234/contacts/bulk -d '{ "contacts": [{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com"}] }'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_lists/1234/contacts/bulk -d '{ "contacts": [{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com"}] }'
 ```
 
 ```python
@@ -431,7 +431,7 @@ POST https://api.surveymonkey.com/v3/contacts
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contacts -d '{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com" }'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contacts -d '{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com" }'
 ```
 
 ```python
@@ -529,7 +529,7 @@ POST https://api.surveymonkey.com/v3/contacts/bulk
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contacts -d '{ "contacts": [{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com" }'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contacts -d '{ "contacts": [{ "first_name": "John", "last_name": "Doe", "email": "test@surveymonkey.com" }'
 ```
 
 ```python
@@ -623,7 +623,7 @@ GET https://api.surveymonkey.com/v3/contacts/{contact_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contacts/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/contacts/1234
 ```
 
 ```python
@@ -688,7 +688,7 @@ GET https://api.surveymonkey.com/v3/contact_fields
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_fields
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/contact_fields
 ```
 
 ```python
@@ -756,7 +756,7 @@ PATCH https://api.surveymonkey.com/v3/contact_fields/{contact_field_id}
 >Example Request
 
 ```shell
-curl -i -X PATCH -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/contact_fields/1 -d '{"label: "5"}'
+curl -i -X PATCH -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/contact_fields/1 -d '{"label: "5"}'
 ```
 
 ```python

--- a/includes/_errors.md
+++ b/includes/_errors.md
@@ -13,7 +13,7 @@ GET https://api.surveymonkey.com/v3/errors
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/errors
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/errors
 ```
 
 ```python
@@ -79,7 +79,7 @@ GET https://api.surveymonkey.com/v3/errors/{error_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/errors/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/errors/1234
 ```
 
 ```python

--- a/includes/_folders.md
+++ b/includes/_folders.md
@@ -15,7 +15,7 @@ POST https://api.surveymonkey.com/v3/survey_folders
 
 ```shell
 
-curl -i -X POST -H "Authorization: bearer YOUR_ACCESS_TOKEN" -H "content-Type":"application/json" https://api.surveymonkey.com/v3/survey_folders -d "{"title":"My Team Folder"}"
+curl -i -X POST -H "Authorization: bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/survey_folders -d "{"title":"My Team Folder"}"
 
 ```
 

--- a/includes/_groups.md
+++ b/includes/_groups.md
@@ -138,7 +138,7 @@ GET https://api.surveymonkey.com/v3/groups/{group_id}/members
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/groups/1234/members
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/groups/1234/members
 ```
 
 ```python
@@ -205,7 +205,7 @@ GET https://api.surveymonkey.com/v3/groups/{group_id}/members/{member_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/groups/1234/members/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/groups/1234/members/1234
 ```
 
 ```python

--- a/includes/_organizations.md
+++ b/includes/_organizations.md
@@ -13,7 +13,7 @@ GET https://api.surveymonkey.com/v3/workgroups
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups
 ```
 
 ```python
@@ -119,7 +119,7 @@ GET https://api.surveymonkey.com/v3/workgroups/{workgroup_id}
 >Example Request
 
 ```shell
-curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups/1234
+curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups/1234
 ```
 
 ```python
@@ -202,7 +202,7 @@ GET https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/members
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/members
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/members
 ```
 
 ```python
@@ -299,7 +299,7 @@ GET https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/members/{member_id
 >Example Request
 
 ```shell
-curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups/1234/members/1234
+curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups/1234/members/1234
 ```
 
 ```python
@@ -360,7 +360,7 @@ GET https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/shares
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/shares
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/shares
 ```
 
 ```python
@@ -458,7 +458,7 @@ GET https://api.surveymonkey.com/v3/workgroups/{workgroup_id}/shares/{share_id}
 >Example Request
 
 ```shell
-curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/workgroups/1234/shares/1234
+curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/workgroups/1234/shares/1234
 ```
 
 ```python
@@ -518,7 +518,7 @@ GET https://api.surveymonkey.com/v3/roles
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/roles
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/roles
 ```
 
 ```python

--- a/includes/_question_bank.md
+++ b/includes/_question_bank.md
@@ -15,7 +15,7 @@ GET https://api.surveymonkey.com/v3/question_bank/questions
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/question_bank/questions
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/question_bank/questions
 ```
 
 ```python

--- a/includes/_questions.md
+++ b/includes/_questions.md
@@ -9,7 +9,7 @@ POST https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questio
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions -d '{"headings": [{"heading": "A question about primates.", "random_assignment": {"percent": 50, "position": 1}},{"heading": "A question about primates phrased slightly differently.", "random_assignment": {"percent": 50, "position": 2},}], "family": "open_ended", "subtype": "single", "position": 1, "sorting": {"type": "textasc","ignore_last": True}, "required": {"text": "This question is required!", "type": "at_least", "amount": "1"},"validation": {"type": "integer","text": "Validation has failed!","min": 20,"max": 30}, "forced_ranking": True, "answers": { #SEE ANSWERS SECTION }}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions -d '{"headings": [{"heading": "A question about primates.", "random_assignment": {"percent": 50, "position": 1}},{"heading": "A question about primates phrased slightly differently.", "random_assignment": {"percent": 50, "position": 2},}], "family": "open_ended", "subtype": "single", "position": 1, "sorting": {"type": "textasc","ignore_last": True}, "required": {"text": "This question is required!", "type": "at_least", "amount": "1"},"validation": {"type": "integer","text": "Validation has failed!","min": 20,"max": 30}, "forced_ranking": True, "answers": { #SEE ANSWERS SECTION }}'
 
 ```
 
@@ -181,7 +181,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/question
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions/{question_id}
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}/questions/{question_id}
 
 ```
 

--- a/includes/_responses.md
+++ b/includes/_responses.md
@@ -277,7 +277,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/responses/bulk
 
 ```shell
 
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/bulk
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/bulk
 ```
 
 ```python
@@ -416,7 +416,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/responses/{respons
 
 ```shell
 
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/{response_id}
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/{response_id}
 ```
 
 ```python
@@ -508,7 +508,7 @@ GET https://api.surveymonkey.com/v3/collectors/{collector_id}/responses/{respons
 
 ```shell
 
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/{response_id}/details
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/{survey_id}/responses/{response_id}/details
 ```
 
 ```python

--- a/includes/_rollups.md
+++ b/includes/_rollups.md
@@ -15,7 +15,7 @@ GET https://api.surveymonkey.com/v3/surveys/{id}/rollups
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/rollups
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/1234/rollups
 ```
 
 ```python
@@ -151,7 +151,7 @@ GET https://api.surveymonkey.com/v3/surveys/{id}/trends
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/trends
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/1234/trends
 ```
 
 ```python

--- a/includes/_surveys.md
+++ b/includes/_surveys.md
@@ -19,7 +19,7 @@ POST https://api.surveymonkey.com/v3/surveys
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys -d '{"title":"My Survey"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys -d '{"title":"My Survey"}'
 ```
 
 ```python
@@ -166,7 +166,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/1234
 ```
 
 ```python
@@ -279,7 +279,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}/details
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/details
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/1234/details
 ```
 
 ```python
@@ -351,7 +351,7 @@ GET https://api.surveymonkey.com/v3/survey_categories
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/survey_categories
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/survey_categories
 ```
 
 ```python
@@ -418,7 +418,7 @@ GET https://api.surveymonkey.com/v3/survey_templates
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/survey_templates?category=all
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/survey_templates?category=all
 ```
 
 ```python
@@ -501,7 +501,7 @@ GET https://api.surveymonkey.com/v3/survey_languages
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/survey_languages
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/survey_languages
 ```
 
 ```python
@@ -568,7 +568,7 @@ POST https://api.surveymonkey.com/v3/surveys/{survey_id}/pages
 >Example Request
 
 ```shell
-curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/pages -d '{"title":"Page Title"}'
+curl -i -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys/1234/pages -d '{"title":"Page Title"}'
 ```
 
 ```python
@@ -644,7 +644,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}/pages/{page_id}
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/surveys/1234/pages/1234
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/1234/pages/1234
 ```
 
 ```python

--- a/includes/_translations.md
+++ b/includes/_translations.md
@@ -15,7 +15,7 @@ GET https://api.surveymonkey.com/v3/surveys/{survey_id}/languages
 
 ```shell
 
-curl -i -X GET -H "Authorization: bearer YOUR_ACCESS_TOKEN" -H "content-Type":"application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/languages
+curl -i -X GET -H "Authorization: bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/surveys/{survey_id}/languages
 
 ```
 
@@ -101,7 +101,7 @@ POST https://api.surveymonkey.com/v3/surveys/{survey_id}/languages/{language_cod
 
 ```shell
 
-curl -i -X POST -H "Authorization: bearer YOUR_ACCESS_TOKEN" -H "content-Type":"application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/languages/fr -d '{"translations":[{"default":"Next","translation":"Suiv.","context":"survey_next","resource_id":"1234"},{"default":"Prev","translation":"Préc.","context":"survey_prev", "resource_id":"1234"},{"default":"Done", "translation":"Terminé", "context":"survey_done", "resource_id":"1234"},{"default":"Exit", "translation":"Quitter", "context":"survey_exit", "resource_id":"1234"
+curl -i -X POST -H "Authorization: bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/surveys/{survey_id}/languages/fr -d '{"translations":[{"default":"Next","translation":"Suiv.","context":"survey_next","resource_id":"1234"},{"default":"Prev","translation":"Préc.","context":"survey_prev", "resource_id":"1234"},{"default":"Done", "translation":"Terminé", "context":"survey_done", "resource_id":"1234"},{"default":"Exit", "translation":"Quitter", "context":"survey_exit", "resource_id":"1234"
       },{"default":"Thank you for completing our survey!", "translation":"Merci d'avoir répondu à notre sondage!", "context":"collector_disqualification", "resource_id":"1234"}, {"default":"Are you multilingual?", "translation":"Êtes-vous multilingue?", "context":"question_heading", "resource_id":"5678"},{"default":"Yes", "translation":"Oui", "context":"question_option_text", "resource_id":"8912"},{"default":"No", "translation":"Non", "context":"question_option_text", "resource_id":"3456"}, {"default":"My Survey", "translation":"Mon Sondage", "context":"survey_title_html", "resource_id":"1234"}], "enabled":true}
 
 ```

--- a/includes/_users.md
+++ b/includes/_users.md
@@ -15,7 +15,7 @@ GET https://api.surveymonkey.com/v3/users/me
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/users/me
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/users/me
 ```
 
 ```python
@@ -108,7 +108,7 @@ GET https://api.surveymonkey.com/v3/users/{user_id}/workgroups
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/users/{user_id}/workgroups
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/users/{user_id}/workgroups
 
 ```python
 import requests
@@ -203,7 +203,7 @@ GET https://api.surveymonkey.com/v3/users/{user_id}/shared
 >Example Request
 
 ```shell
-curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/users/{user_id}/shared
+curl -i -X GET -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/users/{user_id}/shared
 ```
 
 ```python

--- a/includes/_webhooks.md
+++ b/includes/_webhooks.md
@@ -29,7 +29,7 @@ POST https://api.surveymonkey.com/v3/webhooks
 >Example Request
 
 ```shell
-curl -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/webhooks -d \
+curl -X POST -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type: application/json" https://api.surveymonkey.com/v3/webhooks -d \
   '{"name":"My Webhook", "event_type":"response completed", "object_type":"survey", "object_ids":["1234","5678"],"subscription_url":"https://surveymonkey.com/webhook_reciever"}'
 ```
 
@@ -111,7 +111,7 @@ GET https://api.surveymonkey.com/v3/webhooks/{webhook_id}
 >Example Request
 
 ```shell
-curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" -H "Content-Type": "application/json" https://api.surveymonkey.com/v3/webhooks/1234
+curl -H "Authorization:bearer YOUR_ACCESS_TOKEN" https://api.surveymonkey.com/v3/webhooks/1234
 ```
 
 ```python


### PR DESCRIPTION
While playing with your API, I noticed two types of errors with the curl examples that I wanted to fix;

 * incorrect use of Content-Type request header on GET requests
 * invalid curl syntax for inserting the Content-Type header

For consistency, I also changed a few "content-Type" to "Content-Type".

Cheers.