### PR TITLE
Update _webhooks.md

### DIFF
--- a/includes/_webhooks.md
+++ b/includes/_webhooks.md
@@ -195,7 +195,7 @@ api_secret = api_secret.encode("ascii")
 payload = payload.encode("ascii")
 
 signature = hmac.new(
-key='%s&%s' % (api_key, api_secret),
+key=b'%s&%s' % (api_key, api_secret),
 msg=payload,
 digestmod=hashlib.sha1)
 


### PR DESCRIPTION
hmac.new expects key as bytearray or bytes not str.